### PR TITLE
Fix links to formatjs documentation

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -16,9 +16,9 @@
 
 Under the hood, `formatjs` is used for localizing your messages. It allows `svelte-i18n` to support the ICU message syntax. It is strongly recommended to read their documentation about it.
 
-- [Basic Internationalization Principles](https://formatjs.io/docs/basic-internationalization-principles)
-- [Runtime Environments](https://formatjs.io/docs/runtime-requirements)
-- [ICU Message Syntax](https://formatjs.io/docs/icu-syntax)
+- [Basic Internationalization Principles](https://formatjs.io/docs/core-concepts/basic-internationalization-principles)
+- [Runtime Environments](https://formatjs.io/docs/guides/runtime-requirements)
+- [Message Syntax](https://formatjs.io/docs/core-concepts/icu-syntax)
 
 ### `$format` or `$_` or `$t`
 


### PR DESCRIPTION
In [Formatting doc](https://github.com/kaisermann/svelte-i18n/blob/master/docs/Formatting.md) page, 3 links to `formatjs` documentation are broken:
- [Basic Internationalization Principles](https://formatjs.io/docs/basic-internationalization-principles)
- [Runtime Environments](https://formatjs.io/docs/runtime-requirements)
- [ICU Message Syntax](https://formatjs.io/docs/icu-syntax)

This PR fixes the broken urls.